### PR TITLE
https://google.com test, and skip'd http://google.com:80 test

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -2,8 +2,24 @@ use v6;
 use Test;
 use IO::Socket::SSL;
 
-plan 1;
+plan 3;
 
 my $ssl = IO::Socket::SSL.new(:host<github.com>, :port(443));
 isa_ok $ssl, IO::Socket::SSL, 'new 1/1';
 $ssl.close;
+
+subtest {
+    lives_ok { $ssl = IO::Socket::SSL.new(:host<google.com>, :port(443)) };
+    is $ssl.send("GET / HTTP/1.1\r\nHost:www.google.com\r\nConnection:close\r\n\r\n"), 57;
+    ok $ssl.get ~~ /\s200\s/;
+    $ssl.close;
+}, 'google: ssl';
+
+
+skip "Negotiate ssl degrade", 1;
+subtest {
+    return;
+    lives_ok { $ssl = IO::Socket::SSL.new(:host<google.com>, :port(80)) };
+    is $ssl.send("GET / HTTP/1.1\r\nHost:www.google.com\r\nConnection:close\r\n\r\n"), 57;
+    ok $ssl.get ~~ /\s200\s/;
+}, "Connect non-ssl port:80";


### PR DESCRIPTION
The skipped test passing would mean it would be even closer to a IO::Socket::INET drop in. 