### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/IO/Socket/SSL.pm6
+++ b/lib/IO/Socket/SSL.pm6
@@ -1,4 +1,4 @@
-class IO::Socket::SSL;
+unit class IO::Socket::SSL;
 
 use OpenSSL;
 use OpenSSL::Err;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.