### PR TITLE
Make IO::Socket::SSL do the IO::Socket role

### DIFF
--- a/lib/IO/Socket/SSL.pm6
+++ b/lib/IO/Socket/SSL.pm6
@@ -1,4 +1,4 @@
-unit class IO::Socket::SSL;
+unit class IO::Socket::SSL does IO::Socket;
 
 use OpenSSL;
 use OpenSSL::Err;
@@ -11,7 +11,6 @@ sub v6-split($uri) {
     $host ?? ($host, $port) !! $uri;
 }
 
-has Str $.encoding = 'utf8';
 has Str $.host;
 has Int $.port = 443;
 has Str $.localhost;
@@ -124,6 +123,10 @@ method send(Str $s) {
 
 method print(Str $s) {
     $!ssl.write($s);
+}
+
+method put(Str $s) {
+    $!ssl.write($s ~ $.nl-out);
 }
 
 method write(Blob $b) {

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -4,7 +4,7 @@ use IO::Socket::SSL;
 
 plan 2;
 
-my $ssl = IO::Socket::SSL.new(:host<github.com>, :port(443));
+my IO::Socket $ssl = IO::Socket::SSL.new(:host<github.com>, :port(443));
 isa-ok $ssl, IO::Socket::SSL, 'new 1/1';
 $ssl.close;
 


### PR DESCRIPTION
This makes it possible to assign an IO::Socket::SSL to a variable
with an IO::Socket constraint. Without this, doing so would result
in a hard to understand segmentation fault.

In order for this work, the `put` method is also naively implemented.

This fixes #20 and likely #3.