### PR TITLE
Rewrite this module as a IO::Socket::Async frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.precomp/
+*.swp

--- a/META6.json
+++ b/META6.json
@@ -5,7 +5,7 @@
     ],
     "description": "IO::Socket::SSL for Perl 6 using OpenSSL",
     "depends": [
-        "OpenSSL"
+        "IO::Socket::Async::SSL:ver<0.7.14>:auth<zef:jnthn>"
     ],
     "name": "IO::Socket::SSL",
     "perl": "6.*",

--- a/META6.json
+++ b/META6.json
@@ -19,10 +19,9 @@
         "source": "git://github.com/sergot/io-socket-ssl.git"
     },
     "tags": [
-        "SSL", "Sockets"
+        "TLS", "SSL", "Sockets"
     ],
     "test-depends": [
-        "Test"
     ],
     "version": "0.0.3"
 }

--- a/lib/IO/Socket/SSL.rakumod
+++ b/lib/IO/Socket/SSL.rakumod
@@ -20,9 +20,6 @@ has Bool $.listening;
 has Str $.input-line-separator is rw = "\n";
 has Int $.ins = 0;
 
-has $.client-socket;
-has $.listen-socket;
-
 has $!con-tap;
 has Lock $!con-lock;
 has $!con-lock-cond;
@@ -82,12 +79,6 @@ method TWEAK(*%args) {
                     $!con-lock-cond.signal;
                 }
             };
-        }
-        elsif $!client-socket {
-            # TODO
-        }
-        elsif $!listen-socket {
-            # TODO
         }
         else {
             fail "Nothing given for new socket to connect or bind to"

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -1,18 +1,17 @@
-use v6;
 use Test;
 use IO::Socket::SSL;
 
 plan 2;
-
-my IO::Socket $ssl = IO::Socket::SSL.new(:host<github.com>, :port(443));
-isa-ok $ssl, IO::Socket::SSL, 'new 1/1';
-$ssl.close;
 
 unless %*ENV<NETWORK_TESTING> {
     diag "NETWORK_TESTING was not set";
     skip-rest("NETWORK_TESTING was not set");
     exit;
 }
+
+my IO::Socket $ssl = IO::Socket::SSL.new(:host<github.com>, :port(443));
+isa-ok $ssl, IO::Socket::SSL, 'new 1/1';
+$ssl.close;
 
 subtest {
     lives-ok { $ssl = IO::Socket::SSL.new(:host<google.com>, :port(443)) };


### PR DESCRIPTION
This should improve stability, as `IO::Socket::Async::SSL` has seen more
polishing (the basis of Cro) than `IO::Socket::SSL` based on the
`OpenSSL` module, which has at least one known segfault and an endless loop issue.

This improves maintainance as well, as there is only one OpenSSL stack (and
this wrapper) to maintain instead of two stacks (the synchronous and the
asynchronous one).

Two bits of the modules public API were removed:
- `$.accepted-socket`
- `$.ssl`

We need to consider how to best handle this.

Depends on: https://github.com/jnthn/p6-io-socket-async-ssl/pull/73